### PR TITLE
[OLED-259] Benthos Support Max Shard Per Client

### DIFF
--- a/internal/component/input/config_aws_kinesis.go
+++ b/internal/component/input/config_aws_kinesis.go
@@ -31,7 +31,7 @@ func NewDynamoDBCheckpointConfig() DynamoDBCheckpointConfig {
 type AWSKinesisConfig struct {
 	session.Config  `json:",inline" yaml:",inline"`
 	Streams         []string                 `json:"streams" yaml:"streams"`
-	StreamsMaxShard []string 				 `json:"streams_max_shard" yaml:"streams_max_shard"`
+	StreamsMaxShard []string                 `json:"streams_max_shard" yaml:"streams_max_shard"`
 	DynamoDB        DynamoDBCheckpointConfig `json:"dynamodb" yaml:"dynamodb"`
 	CheckpointLimit int                      `json:"checkpoint_limit" yaml:"checkpoint_limit"`
 	CommitPeriod    string                   `json:"commit_period" yaml:"commit_period"`
@@ -46,7 +46,7 @@ func NewAWSKinesisConfig() AWSKinesisConfig {
 	return AWSKinesisConfig{
 		Config:          session.NewConfig(),
 		Streams:         []string{},
-		StreamsMaxShard:  []string{},
+		StreamsMaxShard: []string{},
 		DynamoDB:        NewDynamoDBCheckpointConfig(),
 		CheckpointLimit: 1024,
 		CommitPeriod:    "5s",

--- a/internal/component/input/config_aws_kinesis.go
+++ b/internal/component/input/config_aws_kinesis.go
@@ -46,6 +46,7 @@ func NewAWSKinesisConfig() AWSKinesisConfig {
 	return AWSKinesisConfig{
 		Config:          session.NewConfig(),
 		Streams:         []string{},
+		StreamsMaxShard:  []string{},
 		DynamoDB:        NewDynamoDBCheckpointConfig(),
 		CheckpointLimit: 1024,
 		CommitPeriod:    "5s",

--- a/internal/component/input/config_aws_kinesis.go
+++ b/internal/component/input/config_aws_kinesis.go
@@ -31,7 +31,7 @@ func NewDynamoDBCheckpointConfig() DynamoDBCheckpointConfig {
 type AWSKinesisConfig struct {
 	session.Config  `json:",inline" yaml:",inline"`
 	Streams         []string                 `json:"streams" yaml:"streams"`
-	StreamsMaxShard []string 				 `json:"streams_max-shard" yaml:"streams_max_shard"`
+	StreamsMaxShard []string 				 `json:"streams_max_shard" yaml:"streams_max_shard"`
 	DynamoDB        DynamoDBCheckpointConfig `json:"dynamodb" yaml:"dynamodb"`
 	CheckpointLimit int                      `json:"checkpoint_limit" yaml:"checkpoint_limit"`
 	CommitPeriod    string                   `json:"commit_period" yaml:"commit_period"`

--- a/internal/component/input/config_aws_kinesis.go
+++ b/internal/component/input/config_aws_kinesis.go
@@ -31,6 +31,7 @@ func NewDynamoDBCheckpointConfig() DynamoDBCheckpointConfig {
 type AWSKinesisConfig struct {
 	session.Config  `json:",inline" yaml:",inline"`
 	Streams         []string                 `json:"streams" yaml:"streams"`
+	StreamsMaxShard []string 				 `json:"streams_max-shard" yaml:"streams_max_shard"`
 	DynamoDB        DynamoDBCheckpointConfig `json:"dynamodb" yaml:"dynamodb"`
 	CheckpointLimit int                      `json:"checkpoint_limit" yaml:"checkpoint_limit"`
 	CommitPeriod    string                   `json:"commit_period" yaml:"commit_period"`

--- a/internal/impl/aws/input_kinesis_test.go
+++ b/internal/impl/aws/input_kinesis_test.go
@@ -16,6 +16,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+
+type mockDynamoDbForKinesis struct {
+	dynamodbiface.DynamoDBAPI
+}
+
+func (m *mockDynamoDbForKinesis) UpdateItemWithContext(aws.Context, *dynamodb.UpdateItemInput, ...request.Option) (*dynamodb.UpdateItemOutput, error) {
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+func (m *mockDynamoDbForKinesis) GetItemWithContext(aws.Context, *dynamodb.GetItemInput, ...request.Option) (*dynamodb.GetItemOutput, error){
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (m * mockDynamoDbForKinesis) PutItem(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error){
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+type mockKinesisReader struct {
+	kinesisiface.KinesisAPI
+}
+func (m *mockKinesisReader) GetShardIteratorWithContext(aws.Context, *kinesis.GetShardIteratorInput, ...request.Option) (*kinesis.GetShardIteratorOutput, error){
+	return &kinesis.GetShardIteratorOutput{}, nil
+}
+
 func TestNewKinesisBalancedReaderConfig(t *testing.T) {
 	config := input.NewAWSKinesisConfig()
 	config.Streams = []string{"test-kds-1","test-kds-2"}
@@ -32,42 +55,11 @@ func TestNewKinesisBalancedReaderMaxShardConfig(t *testing.T) {
 	mockManager := mock.NewManager()
 	kinesisReader, err := newKinesisReader(config, mockManager)
 	require.NoError(t, err)
-	assert.Equal(t,len(kinesisReader.balancedStreams), 2)
-	assert.Equal(t,len(kinesisReader.streamMaxShards), 2)
-	assert.Equal(t, kinesisReader.streamMaxShards["test-kds-1"], 5)
-	assert.Equal(t, kinesisReader.streamMaxShards["test-kds-2"], 10)
+	assert.Equal(t, 2, len(kinesisReader.balancedStreams))
+	assert.Equal(t, 2, len(kinesisReader.streamMaxShards))
+	assert.Equal(t,  5, kinesisReader.streamMaxShards["test-kds-1"])
+	assert.Equal(t, 10, kinesisReader.streamMaxShards["test-kds-2"])
 }
-
-type mockDynamoDbKinesis struct {
-	dynamodbiface.DynamoDBAPI
-	updateItemCount int
-	getItemCount int
-	putItemCount int
-}
-
-func (m *mockDynamoDbKinesis) UpdateItemWithContext(aws.Context, *dynamodb.UpdateItemInput, ...request.Option) (*dynamodb.UpdateItemOutput, error) {
-	m.updateItemCount++
-	return &dynamodb.UpdateItemOutput{}, nil
-}
-func (m *mockDynamoDbKinesis) GetItemWithContext(aws.Context, *dynamodb.GetItemInput, ...request.Option) (*dynamodb.GetItemOutput, error){
-	m.getItemCount++
-	return &dynamodb.GetItemOutput{}, nil
-}
-
-func (m * mockDynamoDbKinesis) PutItem(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error){
-	m.putItemCount++
-	return &dynamodb.PutItemOutput{}, nil
-}
-
-type mockKinesisReader struct {
-	kinesisiface.KinesisAPI
-	getShardIteratorContextCount int
-}
-func (m *mockKinesisReader) GetShardIteratorWithContext(aws.Context, *kinesis.GetShardIteratorInput, ...request.Option) (*kinesis.GetShardIteratorOutput, error){
-	m.getShardIteratorContextCount++
-	return &kinesis.GetShardIteratorOutput{}, nil
-}
-
 
 func TestRunMaxShardConfigBalancedShards(t *testing.T){
 
@@ -76,6 +68,8 @@ func TestRunMaxShardConfigBalancedShards(t *testing.T){
 		streams        []string
 		streamsMaxShard []string
 		unclaimedShards map[string]string
+		streamNameToClaim string
+		shardsAlreadyClaimed int
 		expectedIsError         bool
 		expectedNumShardClaimed int
 	}{
@@ -90,28 +84,65 @@ func TestRunMaxShardConfigBalancedShards(t *testing.T){
 				"shard-id-4": "client-id-4",
 				"shard-id-5": "client-id-5",
 			},
+			streamNameToClaim: "test-kds-1",
+			shardsAlreadyClaimed: 1,
 			expectedIsError: false,
 			expectedNumShardClaimed: 4,
 		},
+		{
+			testName: "TestMaxConfigShardLessUnclaimedShards",
+			streams: []string{"test-kds-1","test-kds-2"},
+			streamsMaxShard: []string{"test-kds-1:5","test-kds-2:10"},
+			unclaimedShards: map[string]string{
+				"shard-id-1": "client-id-1",
+				"shard-id-2": "client-id-2",
+				"shard-id-3": "client-id-3",
+				"shard-id-4": "client-id-4",
+				"shard-id-5": "client-id-5",
+				"shard-id-6": "client-id-6",
+				"shard-id-7": "client-id-7",
+			},
+			streamNameToClaim: "test-kds-2",
+			shardsAlreadyClaimed: 0,
+			expectedIsError: false,
+			expectedNumShardClaimed: 7,
+		},
+		{
+			testName: "TestNoMaxShardSet",
+			streams: []string{"test-kds-1","test-kds-2"},
+			streamsMaxShard: []string{""},
+			unclaimedShards: map[string]string{
+				"shard-id-1": "client-id-1",
+				"shard-id-2": "client-id-2",
+				"shard-id-3": "client-id-3",
+				"shard-id-4": "client-id-4",
+				"shard-id-5": "client-id-5",
+				"shard-id-6": "client-id-6",
+				"shard-id-7": "client-id-7",
+			},
+			streamNameToClaim: "test-kds-1",
+			shardsAlreadyClaimed: 0,
+			expectedIsError: false,
+			expectedNumShardClaimed: 7,
+		},
 	}
+
+	// Setup for mocks to be used
+	mockDynamo := mockDynamoDbForKinesis{}
+	mockKinesis := mockKinesisReader{}
+	mockManager := mock.NewManager()
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
 			config := input.NewAWSKinesisConfig()
 			config.Streams = testCase.streams
 			config.StreamsMaxShard = testCase.streamsMaxShard
-			mockManager := mock.NewManager()
 			kinesisReader, _ := newKinesisReader(config, mockManager)
-			mockDynamo := mockDynamoDbKinesis{}
-			mockKinesis := mockKinesisReader{}
 			kinesisReader.svc = &mockKinesis
 			kinesisReader.checkpointer = &awsKinesisCheckpointer{input.NewDynamoDBCheckpointConfig(), "",1, 1, &mockDynamo}
-			numShardClaimed, err := kinesisReader.maxShardRunBalancedConsumer(&sync.WaitGroup{}, "test-kds-1",testCase.unclaimedShards, 1)
-			if (err != nil) != testCase.expectedIsError {
-				t.Errorf("Run balanced shard error error = %v, expected=%v", err, testCase.expectedIsError)
-				return
-			}
-			assert.Equal(t,numShardClaimed, testCase.expectedNumShardClaimed)
+			numShardClaimed, err := kinesisReader.maxShardRunBalancedConsumer(&sync.WaitGroup{}, testCase.streamNameToClaim,testCase.unclaimedShards, testCase.shardsAlreadyClaimed)
+			assert.Equal(t,testCase.expectedIsError, err!=nil)
+			assert.Equal(t,testCase.expectedNumShardClaimed, numShardClaimed)
 
 		})
 	}

--- a/internal/impl/aws/input_kinesis_test.go
+++ b/internal/impl/aws/input_kinesis_test.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/benthosdev/benthos/v4/internal/component/input"
+	"github.com/benthosdev/benthos/v4/internal/manager/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKinesisBalancedReaderConfig(t *testing.T) {
+	config := input.NewAWSKinesisConfig()
+	config.Streams = []string{"test-kds-1","test-kds-2"}
+	mockManager := mock.NewManager()
+	kinesisReader, err := newKinesisReader(config, mockManager)
+	require.NoError(t, err)
+	assert.Equal(t,len(kinesisReader.balancedStreams), 2)
+}
+
+func TestNewKinesisBalancedReaderMaxShardConfig(t *testing.T) {
+	config := input.NewAWSKinesisConfig()
+	config.Streams = []string{"test-kds-1","test-kds-2"}
+	config.StreamsMaxShard = []string{"test-kds-1:5","test-kds-2:10"}
+	mockManager := mock.NewManager()
+	kinesisReader, err := newKinesisReader(config, mockManager)
+	require.NoError(t, err)
+	assert.Equal(t,len(kinesisReader.balancedStreams), 2)
+	assert.Equal(t,len(kinesisReader.streamMaxShards), 2)
+	assert.Equal(t, kinesisReader.streamMaxShards["test-kds-1"], 5)
+	assert.Equal(t, kinesisReader.streamMaxShards["test-kds-2"], 10)
+}
+
+func Test

--- a/internal/impl/aws/input_kinesis_test.go
+++ b/internal/impl/aws/input_kinesis_test.go
@@ -1,8 +1,15 @@
 package aws
 
 import (
+	"sync"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 	"github.com/benthosdev/benthos/v4/internal/component/input"
 	"github.com/benthosdev/benthos/v4/internal/manager/mock"
 	"github.com/stretchr/testify/assert"
@@ -31,4 +38,82 @@ func TestNewKinesisBalancedReaderMaxShardConfig(t *testing.T) {
 	assert.Equal(t, kinesisReader.streamMaxShards["test-kds-2"], 10)
 }
 
-func Test
+type mockDynamoDbKinesis struct {
+	dynamodbiface.DynamoDBAPI
+	updateItemCount int
+	getItemCount int
+	putItemCount int
+}
+
+func (m *mockDynamoDbKinesis) UpdateItemWithContext(aws.Context, *dynamodb.UpdateItemInput, ...request.Option) (*dynamodb.UpdateItemOutput, error) {
+	m.updateItemCount++
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+func (m *mockDynamoDbKinesis) GetItemWithContext(aws.Context, *dynamodb.GetItemInput, ...request.Option) (*dynamodb.GetItemOutput, error){
+	m.getItemCount++
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (m * mockDynamoDbKinesis) PutItem(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error){
+	m.putItemCount++
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+type mockKinesisReader struct {
+	kinesisiface.KinesisAPI
+	getShardIteratorContextCount int
+}
+func (m *mockKinesisReader) GetShardIteratorWithContext(aws.Context, *kinesis.GetShardIteratorInput, ...request.Option) (*kinesis.GetShardIteratorOutput, error){
+	m.getShardIteratorContextCount++
+	return &kinesis.GetShardIteratorOutput{}, nil
+}
+
+
+func TestRunMaxShardConfigBalancedShards(t *testing.T){
+
+	testCases := []struct{
+		testName string
+		streams        []string
+		streamsMaxShard []string
+		unclaimedShards map[string]string
+		expectedIsError         bool
+		expectedNumShardClaimed int
+	}{
+		{
+			testName: "TestMaxConfigShard",
+			streams: []string{"test-kds-1","test-kds-2"},
+			streamsMaxShard: []string{"test-kds-1:5","test-kds-2:10"},
+			unclaimedShards: map[string]string{
+				"shard-id-1": "client-id-1",
+				"shard-id-2": "client-id-2",
+				"shard-id-3": "client-id-3",
+				"shard-id-4": "client-id-4",
+				"shard-id-5": "client-id-5",
+			},
+			expectedIsError: false,
+			expectedNumShardClaimed: 4,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			config := input.NewAWSKinesisConfig()
+			config.Streams = testCase.streams
+			config.StreamsMaxShard = testCase.streamsMaxShard
+			mockManager := mock.NewManager()
+			kinesisReader, _ := newKinesisReader(config, mockManager)
+			mockDynamo := mockDynamoDbKinesis{}
+			mockKinesis := mockKinesisReader{}
+			kinesisReader.svc = &mockKinesis
+			kinesisReader.checkpointer = &awsKinesisCheckpointer{input.NewDynamoDBCheckpointConfig(), "",1, 1, &mockDynamo}
+			numShardClaimed, err := kinesisReader.maxShardRunBalancedConsumer(&sync.WaitGroup{}, "test-kds-1",testCase.unclaimedShards, 1)
+			if (err != nil) != testCase.expectedIsError {
+				t.Errorf("Run balanced shard error error = %v, expected=%v", err, testCase.expectedIsError)
+				return
+			}
+			assert.Equal(t,numShardClaimed, testCase.expectedNumShardClaimed)
+
+		})
+	}
+
+}


### PR DESCRIPTION
### Context
When there are multiple Kinesis clients reading the KDS:
* The first client is greedy and claims as many unclaimed shards as possible
* All remaining clients will now have to try and steal it. This means waiting for the lease timeout to finish/ the initial client to OOM. 

This PR allows us to set in the configuration the max number of shards a client can consume from.

### Intent
* Added in a configuration that you can pass for each stream, the max number of shards each client can claim per stream
* Broke out one of the function into its own so it can be unit tested
* Added in unit tests to ensure that the function is behaving as expected

### Notes
* Did not write any integration tests - the default integration tests always timed out for me whenever i tried running it