### PR TITLE
[OLED-259] Comply Shard stealing with streamMaxShards

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -594,7 +594,7 @@ func (k *kinesisReader) runBalancedShards() {
 			}
 
 			// Note: Stealing only happens if all shards have already been claimed
-			if err = k.stealShards(&wg, streamID, clientClaims); err!=nil {
+			if _, err = k.stealShards(&wg, streamID, clientClaims); err!=nil {
 				return
 			}
 		}

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -594,7 +594,7 @@ func (k *kinesisReader) runBalancedShards() {
 			}
 
 			// Note: Stealing only happens if all shards have already been claimed
-			if _, err = k.stealShard(&wg, streamID, clientClaims); err!=nil {
+			if _, err = k.stealShard(&wg, streamID, clientClaims); err != nil {
 				return
 			}
 		}
@@ -680,16 +680,16 @@ func (k *kinesisReader) maxShardRunBalancedConsumer(wg *sync.WaitGroup, streamID
 	return numShardClaimed, nil
 }
 
-// Function that attempts to steal shards if it meets the following condition:
+// stealShard() attempts to steal shards if it meets the following condition:
 // * It is not its own clientId
 // * It has not reached the max shard number this client can claim
 // * The client it is stealing from has 2 or more shards more than this client currently has
 // It returns True if successful in stealing a shard and any errors if it encountered any
-func (k *kinesisReader) stealShard(wg *sync.WaitGroup, streamID string, clientClaims map[string][]awsKinesisClientClaim) (bool, error){
+func (k *kinesisReader) stealShard(wg *sync.WaitGroup, streamID string, clientClaims map[string][]awsKinesisClientClaim) (bool, error) {
 	// There were no unclaimed shards, let's look for a shard to steal.
 	selfClaims := len(clientClaims[k.clientID])
 	maxShardNumber, maxShardExists := k.streamMaxShards[streamID]
-	isSuccess:= false
+	isSuccess := false
 	for clientID, claims := range clientClaims {
 		if clientID == k.clientID {
 			// Don't steal from ourself, we're not at that point yet.
@@ -734,7 +734,7 @@ func (k *kinesisReader) stealShard(wg *sync.WaitGroup, streamID string, clientCl
 				// for now.
 				isSuccess = true
 				break
-				
+
 			}
 		}
 	}

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -596,8 +596,9 @@ func (k *kinesisReader) runBalancedShards() {
 
 			// Note: Stealing only happens if all shards have already been claimed
 			err = k.stealShard(&wg, streamID, clientClaims)
-			if !(err == nil || err == errShardNotStolen) {
-				return
+			if err != nil && !errors.Is(err, errShardNotStolen) {
+				k.log.Errorf("Stealing shards had failed: %v", err)
+				return 
 			}
 		}
 

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -598,7 +598,7 @@ func (k *kinesisReader) runBalancedShards() {
 			err = k.stealShard(&wg, streamID, clientClaims)
 			if err != nil && !errors.Is(err, errShardNotStolen) {
 				k.log.Errorf("Stealing shards had failed: %v", err)
-				return 
+				return
 			}
 		}
 
@@ -688,7 +688,7 @@ func (k *kinesisReader) maxShardRunBalancedConsumer(wg *sync.WaitGroup, streamID
 // * It has not reached the max shard number this client can claim
 // * The client it is stealing from has 2 or more shards more than this client currently has
 // It returns nil if it succesfully steals a shard, otherwise returns error errShardNotStolen if shards are not stolen or any errors if it encountered any
-func (k *kinesisReader) stealShard(wg *sync.WaitGroup, streamID string, clientClaims map[string][]awsKinesisClientClaim) ( error) {
+func (k *kinesisReader) stealShard(wg *sync.WaitGroup, streamID string, clientClaims map[string][]awsKinesisClientClaim) error {
 	// There were no unclaimed shards, let's look for a shard to steal.
 	selfClaims := len(clientClaims[k.clientID])
 	maxShardNumber, maxShardExists := k.streamMaxShards[streamID]

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -208,9 +208,9 @@ func newKinesisReader(conf input.AWSKinesisConfig, mgr bundle.NewManagement) (*k
 			for _, stream := range k.balancedStreams {
 				numShards, exists := k.streamMaxShards[stream]
 				if exists {
-					k.log.Infof("this client will only read %v shards for stream:%v\n", numShards, stream)
+					k.log.Infof("For stream:%v\n, this client will read %v shards", stream, numShards)
 				} else {
-					k.log.Infof("No max number of shard defined for the stream:%v, goes back to default behaviour\n", stream)
+					k.log.Infof("No max number of shard defined for the stream:%v, falling back to default behaviour\n", stream)
 				}
 
 			}

--- a/internal/impl/aws/input_kinesis_test.go
+++ b/internal/impl/aws/input_kinesis_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These mocks are used to mock the underlying AWS Api that is called by runConsumer()
+// mockDynamoDbForKinesis and mockKinesisReader is used to mock the underlying AWS API that is called by runConsumer()
 // The following tests only runs through the happy path of the runConsumer() code
 type mockDynamoDbForKinesis struct {
 	dynamodbiface.DynamoDBAPI
@@ -191,7 +191,7 @@ func createKinesisClientClaim(numShards int) []awsKinesisClientClaim {
 	return clientClaims
 }
 
-func TestStealShards(t *testing.T) {
+func TestStealShard(t *testing.T) {
 
 	testCases := []struct {
 		testName          string
@@ -274,7 +274,7 @@ func TestStealShards(t *testing.T) {
 			kinesisReader.svc = &mockKinesis
 			kinesisReader.clientID = testCase.clientId
 			kinesisReader.checkpointer = &awsKinesisCheckpointer{input.NewDynamoDBCheckpointConfig(), "", 1, 1, &mockDynamo}
-			isSuccess, err := kinesisReader.stealShards(&sync.WaitGroup{}, testCase.streamNameToClaim, testCase.clientClaims)
+			isSuccess, err := kinesisReader.stealShard(&sync.WaitGroup{}, testCase.streamNameToClaim, testCase.clientClaims)
 			assert.Equal(t, testCase.expectedIsError, err != nil)
 			assert.Equal(t, testCase.expectedIsSuccess, isSuccess)
 

--- a/internal/impl/aws/input_kinesis_test.go
+++ b/internal/impl/aws/input_kinesis_test.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"sync"
 	"testing"
+	"github.com/benthosdev/benthos/v4/internal/batch/policy/batchconfig"
+	"github.com/benthosdev/benthos/v4/internal/impl/aws/session"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -16,6 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+
+//These mocks are used to mock the underlying AWS Api that is called by runConsumer()
+// The following tests only runs through the happy path of it
 type mockDynamoDbForKinesis struct {
 	dynamodbiface.DynamoDBAPI
 }
@@ -30,30 +35,60 @@ func (m *mockDynamoDbForKinesis) GetItemWithContext(aws.Context, *dynamodb.GetIt
 func (m *mockDynamoDbForKinesis) PutItem(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
 	return &dynamodb.PutItemOutput{}, nil
 }
+func (m *mockDynamoDbForKinesis)  DeleteItemWithContext(aws.Context, *dynamodb.DeleteItemInput, ...request.Option) (*dynamodb.DeleteItemOutput, error){
+	return &dynamodb.DeleteItemOutput{},nil
+
+}
 
 type mockKinesisReader struct {
 	kinesisiface.KinesisAPI
 }
 
 func (m *mockKinesisReader) GetShardIteratorWithContext(aws.Context, *kinesis.GetShardIteratorInput, ...request.Option) (*kinesis.GetShardIteratorOutput, error) {
-	return &kinesis.GetShardIteratorOutput{}, nil
+	shardId := "2"
+	return &kinesis.GetShardIteratorOutput{ShardIterator: &shardId}, nil
+}
+
+func (m *mockKinesisReader)  GetRecordsWithContext(aws.Context, *kinesis.GetRecordsInput, ...request.Option) (*kinesis.GetRecordsOutput, error) {
+	milisecondsBehind := int64(0)
+	return &kinesis.GetRecordsOutput{
+		ChildShards: []*kinesis.ChildShard{},
+		MillisBehindLatest: &milisecondsBehind,
+		NextShardIterator: nil,
+		Records: []*kinesis.Record{},
+	}, nil
+}
+
+
+
+
+
+func NewAwsTestConfig(streams[]string, streamsMaxShard []string) input.AWSKinesisConfig {
+	return input.AWSKinesisConfig{
+		Config:          session.NewConfig(),
+		Streams:         streams,
+		StreamsMaxShard: streamsMaxShard,
+		DynamoDB:        input.NewDynamoDBCheckpointConfig(),
+		CheckpointLimit: 1024,
+		CommitPeriod:    "5s",
+		LeasePeriod:     "30s",
+		RebalancePeriod: "30s",
+		StartFromOldest: true,
+		Batching:        batchconfig.NewConfig(),
+	}
 }
 
 func TestNewKinesisBalancedReaderConfig(t *testing.T) {
 	config := input.NewAWSKinesisConfig()
 	config.Streams = []string{"test-kds-1", "test-kds-2"}
-	mockManager := mock.NewManager()
-	kinesisReader, err := newKinesisReader(config, mockManager)
+	kinesisReader, err := newKinesisReader(config, mock.NewManager())
 	require.NoError(t, err)
 	assert.Equal(t, len(kinesisReader.balancedStreams), 2)
 }
 
 func TestNewKinesisBalancedReaderMaxShardConfig(t *testing.T) {
-	config := input.NewAWSKinesisConfig()
-	config.Streams = []string{"test-kds-1", "test-kds-2"}
-	config.StreamsMaxShard = []string{"test-kds-1:5", "test-kds-2:10"}
-	mockManager := mock.NewManager()
-	kinesisReader, err := newKinesisReader(config, mockManager)
+	config := NewAwsTestConfig( []string{"test-kds-1", "test-kds-2"}, []string{"test-kds-1:5", "test-kds-2:10"})
+	kinesisReader, err := newKinesisReader(config, mock.NewManager())
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(kinesisReader.balancedStreams))
 	assert.Equal(t, 2, len(kinesisReader.streamMaxShards))
@@ -134,9 +169,7 @@ func TestRunMaxShardConfigBalancedShards(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
-			config := input.NewAWSKinesisConfig()
-			config.Streams = testCase.streams
-			config.StreamsMaxShard = testCase.streamsMaxShard
+			config := NewAwsTestConfig(testCase.streams,testCase.streamsMaxShard )
 			kinesisReader, _ := newKinesisReader(config, mockManager)
 			kinesisReader.svc = &mockKinesis
 			kinesisReader.checkpointer = &awsKinesisCheckpointer{input.NewDynamoDBCheckpointConfig(), "", 1, 1, &mockDynamo}
@@ -148,3 +181,52 @@ func TestRunMaxShardConfigBalancedShards(t *testing.T) {
 	}
 
 }
+
+// func TestStealShards(t *testing.T) {
+// 	testCases := []struct {
+// 		testName                string
+// 		streams                 []string
+// 		streamsMaxShard         []string
+// 		unclaimedShards         map[string]string
+// 		streamNameToClaim       string
+// 		shardsAlreadyClaimed    int
+// 		expectedIsError         bool
+// 		expectedNumShardClaimed int
+// 	}{
+// 		{
+// 			testName:        "TestMaxConfigShard",
+// 			streams:         []string{"test-kds-1", "test-kds-2"},
+// 			streamsMaxShard: []string{"test-kds-1:5", "test-kds-2:10"},
+// 			unclaimedShards: map[string]string{
+// 				"shard-id-1": "client-id-1",
+// 				"shard-id-2": "client-id-2",
+// 				"shard-id-3": "client-id-3",
+// 				"shard-id-4": "client-id-4",
+// 				"shard-id-5": "client-id-5",
+// 			},
+// 			streamNameToClaim:       "test-kds-1",
+// 			expectedIsError:         false,
+// 		},
+// 	}
+
+// 		// Setup for mocks to be used.
+// 		mockDynamo := mockDynamoDbForKinesis{}
+// 		mockKinesis := mockKinesisReader{}
+// 		mockManager := mock.NewManager()
+
+// 	for _, testCase := range testCases {
+// 		t.Run(testCase.testName, func(t *testing.T) {
+// 			config := input.NewAWSKinesisConfig()
+// 			config.Streams = testCase.streams
+// 			config.StreamsMaxShard = testCase.streamsMaxShard
+// 			kinesisReader, _ := newKinesisReader(config, mockManager)
+// 			kinesisReader.svc = &mockKinesis
+// 			kinesisReader.checkpointer = &awsKinesisCheckpointer{input.NewDynamoDBCheckpointConfig(), "", 1, 1, &mockDynamo}
+// 			numShardClaimed, err := kinesisReader.stealShards(&sync.WaitGroup{}, testCase.streamNameToClaim, testCase.unclaimedShards)
+// 			// assert.Equal(t, testCase.expectedIsError, err != nil)
+// 			// assert.Equal(t, testCase.expectedNumShardClaimed, numShardClaimed)
+
+// 		})
+// 	}
+
+// }

--- a/internal/impl/aws/input_kinesis_test.go
+++ b/internal/impl/aws/input_kinesis_test.go
@@ -269,9 +269,7 @@ func TestStealShards(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
-			config := input.NewAWSKinesisConfig()
-			config.Streams = testCase.streams
-			config.StreamsMaxShard = testCase.streamsMaxShard
+			config := NewAwsTestConfig(testCase.streams, testCase.streamsMaxShard)
 			kinesisReader, _ := newKinesisReader(config, mockManager)
 			kinesisReader.svc = &mockKinesis
 			kinesisReader.clientID = testCase.clientId


### PR DESCRIPTION
### Context
* Added streamMaxShards config in this PR - https://github.com/Canva/benthos/pull/1
* However the stealing still occurs and doesnt comply with the configuration because that part does not have the additional check

### Changes made
* Moved the part of the function into the function called `stealShards` so it is testable and added the `streamMaxShards` check
* Added tests to ensure it is working as expected
* Fixed up the logger message