### PR TITLE
Add kinesis timestamp

### DIFF
--- a/internal/impl/aws/input_kinesis_record_batcher.go
+++ b/internal/impl/aws/input_kinesis_record_batcher.go
@@ -53,6 +53,10 @@ func (a *awsKinesisRecordBatcher) AddRecord(r *kinesis.Record) bool {
 	if r.PartitionKey != nil {
 		p.MetaSetMut("kinesis_partition_key", *r.PartitionKey)
 	}
+	if r.ApproximateArrivalTimestamp !=nil {
+		iteratorAge := time.Now().UnixNano() - r.ApproximateArrivalTimestamp.UnixNano()
+		p.MetaSetMut("kinesis_iterator_age", iteratorAge)
+	}
 	p.MetaSetMut("kinesis_sequence_number", *r.SequenceNumber)
 
 	a.batchedSequence = *r.SequenceNumber

--- a/internal/impl/aws/input_kinesis_record_batcher.go
+++ b/internal/impl/aws/input_kinesis_record_batcher.go
@@ -53,7 +53,7 @@ func (a *awsKinesisRecordBatcher) AddRecord(r *kinesis.Record) bool {
 	if r.PartitionKey != nil {
 		p.MetaSetMut("kinesis_partition_key", *r.PartitionKey)
 	}
-	if r.ApproximateArrivalTimestamp !=nil {
+	if r.ApproximateArrivalTimestamp != nil {
 		iteratorAge := time.Now().UnixNano() - r.ApproximateArrivalTimestamp.UnixNano()
 		p.MetaSetMut("kinesis_iterator_age", iteratorAge)
 	}


### PR DESCRIPTION
### Context
* Currently, it is difficult to know which shards are being consumed and how far back it is being consumed
* We want to submit a metric to know which shards are being processed and how behind they are when consuming from kinesis. 
* This metric is not possible with the current information that we have as the `ApproximateArrivalTimestamp` is not being sent as metadata. Additionally, it is more accurate if the calculation is done at the start rather than at the end.


### Intent
