### PR TITLE
Ignore batching period time on shutdown signal

### DIFF
--- a/internal/impl/pure/output_switch.go
+++ b/internal/impl/pure/output_switch.go
@@ -369,6 +369,10 @@ func (o *switchOutput) loop() {
 	var ackPending int64
 
 	defer func() {
+		for _, tChan := range o.outputTSChans {
+			close(tChan)
+		}
+
 		// Wait for pending acks to be resolved, or forceful termination
 	ackWaitLoop:
 		for atomic.LoadInt64(&ackPending) > 0 {
@@ -380,9 +384,7 @@ func (o *switchOutput) loop() {
 				break ackWaitLoop
 			}
 		}
-		for _, tChan := range o.outputTSChans {
-			close(tChan)
-		}
+
 		for _, output := range o.outputs {
 			output.TriggerCloseNow()
 		}


### PR DESCRIPTION
Switch:
- Force batcher to flush when receiving a shutdown signal by closing the message receiving channel before waiting for pending acks

Batcher:
- Ignore the batching period when the receiving channel is closed
- Wait for all the batches to be acked by the underlying output (in our case s3) before shutting down