### PR TITLE
Add record iterator age as a meta

### DIFF
--- a/internal/impl/aws/input_kinesis_record_batcher.go
+++ b/internal/impl/aws/input_kinesis_record_batcher.go
@@ -54,6 +54,7 @@ func (a *awsKinesisRecordBatcher) AddRecord(r *kinesis.Record) bool {
 		p.MetaSetMut("kinesis_partition_key", *r.PartitionKey)
 	}
 	p.MetaSetMut("kinesis_sequence_number", *r.SequenceNumber)
+	p.MetaSetMut("kinesis_iterator_age", time.Since(*r.ApproximateArrivalTimestamp).Nanoseconds())
 
 	a.batchedSequence = *r.SequenceNumber
 	if a.flushedMessage != nil {


### PR DESCRIPTION
Add iterator age as a new meta. Adding it as nanosecod so we can use it later in a `timing` metric as described here:

https://www.benthos.dev/docs/components/processors/metric#timing