### PR TITLE
Create new canva aws public package 

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -750,7 +750,8 @@ func (k *kinesisReader) stealShard(wg *sync.WaitGroup, streamID string, clientCl
 	return errShardNotStolen
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
 // Connect establishes a kafkaReader connection.
 func (k *kinesisReader) Connect(ctx context.Context) error {
 	k.cMut.Lock()

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -750,8 +750,7 @@ func (k *kinesisReader) stealShard(wg *sync.WaitGroup, streamID string, clientCl
 	return errShardNotStolen
 }
 
-//------------------------------------------------------------------------------
-
+// ------------------------------------------------------------------------------
 // Connect establishes a kafkaReader connection.
 func (k *kinesisReader) Connect(ctx context.Context) error {
 	k.cMut.Lock()

--- a/public/components/canva_aws/package.go
+++ b/public/components/canva_aws/package.go
@@ -1,0 +1,7 @@
+package canva_aws
+
+// Specific package for canva purposes because we do not need additional dependencies with elasticsearch and kafka
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/benthosdev/benthos/v4/internal/impl/aws"
+)


### PR DESCRIPTION
### Context
The current aws package include dependencies to kafka. This kafka brings in an indirect dependency to a library called sarama. A new application want to upgrade sarama but this is incompatible with the current kafka function in Benthos

### Intent
To resolve this issue, we should not need to use the `public/components/aws` because it has dependency to kafka. We create a new package that only points to `aws` internal benthos package. This in turn would mean that benthos no longer has dependency on kafka/sarama library.