### PR TITLE
Add root-level OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+set noparent
+
+phoebe@canva.com
+sasan@canva.com


### PR DESCRIPTION
# Context
AppSec is rolling out [Security Scorecards (Security Pulse)](https://canvadev.atlassian.net/browse/ASTP-71). As part of this goal, AppSec will associate all Dependabot findings with a team according to the `OWNERS` files and the repository. This repository does not have a root-level `OWNERS` file, so we are adding one to improve ownership coverage.

# Intent
Add root-level `OWNERS` file to this repository

# Changes
New `OWNERS` file in the repository root level. The ownership is gathered from repository terraform definition in https://github.com/Canva/infrastructure/blob/master/github/repositories/benthos/OWNERS