### PR TITLE
[OLED-547] Fix long wait time on lease stealing

### DIFF
--- a/internal/impl/aws/input_kinesis_checkpointer.go
+++ b/internal/impl/aws/input_kinesis_checkpointer.go
@@ -20,6 +20,7 @@ import (
 // Common errors that might occur throughout checkpointing.
 var (
 	ErrLeaseNotAcquired = errors.New("the shard could not be leased due to a collision")
+	ErrNoSequenceNum    = errors.New("sequence ID was not found in checkpoint")
 )
 
 // awsKinesisCheckpointer manages the shard checkpointing for a given client
@@ -130,7 +131,7 @@ func (k *awsKinesisCheckpointer) getCheckpoint(ctx context.Context, streamID, sh
 	if s, ok := rawItem.Item["SequenceNumber"]; ok && s.S != nil {
 		c.SequenceNumber = *s.S
 	} else {
-		return nil, errors.New("sequence ID was not found in checkpoint")
+		return nil, ErrNoSequenceNum
 	}
 
 	if s, ok := rawItem.Item["ClientID"]; ok && s.S != nil {
@@ -282,23 +283,59 @@ func (k *awsKinesisCheckpointer) Claim(ctx context.Context, streamID, shardID, f
 	// This allows the victim client to update the checkpoint with the final
 	// sequence as it yields the shard.
 	if len(fromClientID) > 0 && time.Since(currentLease) < k.leaseDuration {
-		// Wait for the estimated next checkpoint time plus a grace period of
-		// one second.
 		waitFor := k.leaseDuration - time.Since(currentLease) + time.Second
-		select {
-		case <-time.After(waitFor):
-		case <-ctx.Done():
-			return "", ctx.Err()
+		timer := time.NewTimer(waitFor)
+	FOR_LOOP:
+		for {
+			checkPointed, err := k.isCheckpointed(ctx, streamID, shardID, startingSequence)
+			if err != nil {
+				return "", err
+			}
+
+			if checkPointed {
+				break
+			}
+
+			// Wait for the estimated next checkpoint time plus a grace period of
+			// one second.
+			select {
+			case <-time.After(time.Second * 30):
+			case <-timer.C:
+				break FOR_LOOP
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
 		}
 
 		cp, err := k.getCheckpoint(ctx, streamID, shardID)
-		if err != nil {
+		switch {
+		case err == ErrNoSequenceNum:
+			return "", nil
+		case err != nil:
 			return "", err
 		}
 		startingSequence = cp.SequenceNumber
 	}
 
 	return startingSequence, nil
+}
+
+// Attempts to determine whether a shard has been checkpointed depending on the starting sequenceNumber
+// If there has been no checkpoint on that shard, then resume from start of shard.
+func (k *awsKinesisCheckpointer) isCheckpointed(ctx context.Context, streamID, shardID, sequenceNumber string) (bool, error) {
+	item, err := k.getCheckpoint(ctx, streamID, shardID)
+	switch {
+	case err == ErrNoSequenceNum:
+		return true, nil
+	case err != nil:
+		return false, err
+	}
+
+	if item.SequenceNumber != sequenceNumber {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Checkpoint attempts to set a sequence number for a stream shard. Returns a


### PR DESCRIPTION
https://canvadev.atlassian.net/browse/OLED-547

The issue mentioned within the ticket https://canvadev.atlassian.net/browse/OLED-547 is that when we steal shards, the code currently naively waits for `waitFor := k.leaseDuration - time.Since(currentLease) + time.Second`
Until it finally grabs the checkpoint and performs the lease steal.

This is problematic when we perform a rolling deployment
- 5 pods reading from 5 shards
- 1 new pod is spun up
- All 5 previous pods initiate graceful shutdown
- The one new pod attempts to steal a lease
- While attempt to steal a lease, it sees that previous pods have a claim of k.LeaseDuration
- It waits for waitFor
- The previous pods complete graceful shutdown
- Our new pod is still waiting for waitFor even though the previous pod has completed shutdown

Therefore, we’ve solved this issue by checking every 30 seconds within a loop for whether the graceful shutdown has completed. We implemented this by checking if the checkpointed sequence number of the shard is different from the start sequence number. Therefore now we only need to wait for an interval of 30 seconds.

Shard stealing only happens one shard at a time. After that shard is stolen, we go back to the main loop which checks for which shards are unclaimed before trying to steal another shard.

Ideally during the process of waiting for the shard to have been checkpointed, other terminating pods would have finished shutting down, therefore now being marked as unclaimed. We can now simply try and claim those shards immediately now.


https://docs.google.com/document/d/1OxjqtjsOEu61npKE2Zcn6EZk9urEddPKvtJH0zwqGKE/edit#heading=h.bxnhrpu89iai