### PR TITLE
Fix Benthos ListShards Pagination

### DIFF
--- a/internal/component/input/config_aws_kinesis.go
+++ b/internal/component/input/config_aws_kinesis.go
@@ -29,30 +29,32 @@ func NewDynamoDBCheckpointConfig() DynamoDBCheckpointConfig {
 
 // AWSKinesisConfig is configuration values for the input type.
 type AWSKinesisConfig struct {
-	session.Config  `json:",inline" yaml:",inline"`
-	Streams         []string                 `json:"streams" yaml:"streams"`
-	StreamsMaxShard []string                 `json:"streams_max_shard" yaml:"streams_max_shard"`
-	DynamoDB        DynamoDBCheckpointConfig `json:"dynamodb" yaml:"dynamodb"`
-	CheckpointLimit int                      `json:"checkpoint_limit" yaml:"checkpoint_limit"`
-	CommitPeriod    string                   `json:"commit_period" yaml:"commit_period"`
-	LeasePeriod     string                   `json:"lease_period" yaml:"lease_period"`
-	RebalancePeriod string                   `json:"rebalance_period" yaml:"rebalance_period"`
-	StartFromOldest bool                     `json:"start_from_oldest" yaml:"start_from_oldest"`
-	Batching        batchconfig.Config       `json:"batching" yaml:"batching"`
+	session.Config     `json:",inline" yaml:",inline"`
+	Streams            []string                 `json:"streams" yaml:"streams"`
+	StreamsMaxShard    []string                 `json:"streams_max_shard" yaml:"streams_max_shard"`
+	DynamoDB           DynamoDBCheckpointConfig `json:"dynamodb" yaml:"dynamodb"`
+	CheckpointLimit    int                      `json:"checkpoint_limit" yaml:"checkpoint_limit"`
+	CommitPeriod       string                   `json:"commit_period" yaml:"commit_period"`
+	LeasePeriod        string                   `json:"lease_period" yaml:"lease_period"`
+	RebalancePeriod    string                   `json:"rebalance_period" yaml:"rebalance_period"`
+	StartFromOldest    bool                     `json:"start_from_oldest" yaml:"start_from_oldest"`
+	ListShardsAtLatest bool                     `json:"list_shards_at_latest" yaml:"list_shards_at_latest"`
+	Batching           batchconfig.Config       `json:"batching" yaml:"batching"`
 }
 
 // NewAWSKinesisConfig creates a new Config with default values.
 func NewAWSKinesisConfig() AWSKinesisConfig {
 	return AWSKinesisConfig{
-		Config:          session.NewConfig(),
-		Streams:         []string{},
-		StreamsMaxShard: []string{},
-		DynamoDB:        NewDynamoDBCheckpointConfig(),
-		CheckpointLimit: 1024,
-		CommitPeriod:    "5s",
-		LeasePeriod:     "30s",
-		RebalancePeriod: "30s",
-		StartFromOldest: true,
-		Batching:        batchconfig.NewConfig(),
+		Config:             session.NewConfig(),
+		Streams:            []string{},
+		StreamsMaxShard:    []string{},
+		DynamoDB:           NewDynamoDBCheckpointConfig(),
+		CheckpointLimit:    1024,
+		CommitPeriod:       "5s",
+		LeasePeriod:        "30s",
+		RebalancePeriod:    "30s",
+		StartFromOldest:    true,
+		ListShardsAtLatest: false,
+		Batching:           batchconfig.NewConfig(),
 	}
 }

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -563,7 +563,7 @@ func (k *kinesisReader) getShardsResult(streamID string) (*kinesis.ListShardsOut
 		return totalShardRes, err
 	}
 	nextToken := totalShardRes.NextToken
-	for nextToken != nil && *nextToken != "" {
+	for aws.StringValue(nextToken) != "" {
 		shardRes, err := k.svc.ListShardsWithContext(k.ctx, &kinesis.ListShardsInput{NextToken: nextToken})
 		if len(shardRes.Shards) > 0 {
 			totalShardRes.SetShards(append(totalShardRes.Shards, shardRes.Shards...))


### PR DESCRIPTION
### Context
Last night with the kinesis stream shard increase, the number of shards had exceeded the `ListShardswithContext` API limit of 1000.

Benthos has no pagination for that API and so not all shards that were opened were picked up.

### Intent
* Support in Benthos > 1000 Shards by querying `ListShardswithContext` for `nextToken`
* Added config support for `ListShardsAtLatest` as a bool so we can enable that in the future as an environment variable if we want to

### Other questions
1. **Why not just have it set as `AT_LATEST` as default?**
I think there are some use cases where it is good have the closed shards available. For example during a scale up and if the pods reading from the parent shard id (e.g. `1`) crashes and the shard closes, then Benthos will not pick up and read the remaining records in the shard and there will be data loss.

2. **If it is better to list the closed shards, why have `AT_LATEST`?**
The issue is that we hard code the number of shards each pod should consume from. We could possibly overwhelm one pod as we do not have a way to distribute the traffic load: For example, each pod only has enough memory capacity to run 1 shard and say the stream has 2 shards but due to the resharding, the `ListShardswithContext` returns 4 shards. 

We now need to update the benthos config to take up 2 shards per pod. It could lead to this:

- Pod 1: {Shard 1; Closed, Shard 2: closed}
- Pod 2: {Shard 3: new open shard, Shard 4: new open shard}

and Pod 2 OOMs.

In worst case scenario, having `AT_LATEST` can give the oncall engineer to be able to toggle this to ensure even distribution of load. 