### PR TITLE
[OLED-1952] Submit kinesis shard id state

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -586,6 +586,9 @@ func (k *kinesisReader) runBalancedShards() {
 		})
 	}()
 
+	// Create a gauge metric for shard status
+	metricKVectorShardStatus := k.mgr.Metrics().GetGaugeVec("kinesis_shard_status", "stream", "shard_id", "status")
+
 	for {
 		for _, streamID := range k.balancedStreams {
 			shardsRes, err := k.getShardsResult(streamID)
@@ -604,7 +607,11 @@ func (k *kinesisReader) runBalancedShards() {
 			totalShards := len(shardsRes.Shards)
 			unclaimedShards := make(map[string]string, totalShards)
 			for _, s := range shardsRes.Shards {
-				if !isShardFinished(s) {
+				// Update metric for each shard
+				if isShardFinished(s) {
+					metricKVectorShardStatus.With(streamID, *s.ShardId, "finished").Set(1)
+				} else {
+					metricKVectorShardStatus.With(streamID, *s.ShardId, "open").Set(1)
 					unclaimedShards[*s.ShardId] = ""
 				}
 			}

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -587,7 +587,7 @@ func (k *kinesisReader) runBalancedShards() {
 	}()
 
 	// Create a gauge metric for shard status
-	metricKVectorShardStatus := k.mgr.Metrics().GetGaugeVec("kinesis_shard_status", "stream", "shard_id", "status")
+	metricKVectorShardStatus := k.mgr.Metrics().GetGaugeVec("kinesis_shard_opened", "stream", "shard_id")
 
 	for {
 		for _, streamID := range k.balancedStreams {
@@ -609,9 +609,9 @@ func (k *kinesisReader) runBalancedShards() {
 			for _, s := range shardsRes.Shards {
 				// Update metric for each shard
 				if isShardFinished(s) {
-					metricKVectorShardStatus.With(streamID, *s.ShardId, "finished").Set(1)
+					metricKVectorShardStatus.With(streamID, *s.ShardId).Set(0)
 				} else {
-					metricKVectorShardStatus.With(streamID, *s.ShardId, "open").Set(1)
+					metricKVectorShardStatus.With(streamID, *s.ShardId).Set(1)
 					unclaimedShards[*s.ShardId] = ""
 				}
 			}


### PR DESCRIPTION
### Context
With no aws metrics, our composite monitor for s3-sink for stop reading pods, can cause false positive. 

I was in the middle of writing the eng handbook because that is the resolution we can up with in this discussion:
https://canva.slack.com/archives/C04EHH55USJ/p1753673513436649

however, i looked at the number of shards closed during a scale up - there can be up to 2k of shards closing. It isnt sustainable to have to mute every shard id that had closed and if we were to mute the entire monitor, im also unsure when we should unmute it.

### Intent
I think it is better submit a metric so we know if the shard is open or not:

* Going to submit a metric from the s3-sink about whether a shard is finished or not. 

### Note
I have tested locally

```
# TYPE kinesis_shard_status gauge
kinesis_shard_status{label="kinesis",path="root.input_resources",shard_id="shardId-000000000000",status="open",stream="s3-sink-local"} 1
```