### PR TITLE
[OLED-1951] Rename shard_id to shardId

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -587,7 +587,7 @@ func (k *kinesisReader) runBalancedShards() {
 	}()
 
 	// Create a gauge metric for shard status
-	metricKVectorShardStatus := k.mgr.Metrics().GetGaugeVec("kinesis_shard_opened", "stream", "shard_id")
+	metricKVectorShardStatus := k.mgr.Metrics().GetGaugeVec("kinesis_shard_opened", "stream", "shardId")
 
 	for {
 		for _, streamID := range k.balancedStreams {


### PR DESCRIPTION
### Context
* This is a follow up of this PR - https://github.com/Canva/benthos/pull/38

### Issue
I have to join two metrics together for the composite monitor. The issue is that because the other metric label is called `shardId` and the `kinesis_shard_opened` metric is called `shard_id`, it requires a label_replace to join the two metrics together.

As i am not keen and want uniformity as this becomes tech debt, changing `shard_id` to `shardId`

```
(
  sum by(shardId) (increase(kinesis_reader_count{k8s_cluster_name="telemetry-aws-use1-nonprod-baboon", k8s_namespace_name="s3-sink"}[5m])) > 1
) 
and 
(
  min by(shardId) (
    label_replace(
      kinesis_shard_opened{k8s_cluster_name="telemetry-aws-use1-nonprod-baboon", k8s_namespace_name="s3-sink"},
      "shardId", 
      "$1", 
      "shard_id", 
      "(.*)"
    )
  ) == 1
)
```